### PR TITLE
Set default eComm device in addition to eConsole. Bumped minor ver.

### DIFF
--- a/ALsSoundSwitcher_Frontend/ALsSoundSwitcher/Properties/AssemblyInfo.cs
+++ b/ALsSoundSwitcher_Frontend/ALsSoundSwitcher/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.3.5")]
-[assembly: AssemblyFileVersion("2.3.5")]
+[assembly: AssemblyVersion("2.4.0")]
+[assembly: AssemblyFileVersion("2.4.0")]

--- a/SetPlaybackDevice/SetPlaybackDevice/Device.hpp
+++ b/SetPlaybackDevice/SetPlaybackDevice/Device.hpp
@@ -1,6 +1,6 @@
 #include "Includes.h"
 
-HRESULT SetAudioPlaybackDevice(const LPCWSTR devID)
+HRESULT SetAudioPlaybackDevice(const LPCWSTR devID, ERole role)
 {
 		HRESULT hr;
 
@@ -8,13 +8,11 @@ HRESULT SetAudioPlaybackDevice(const LPCWSTR devID)
 
 		IPolicyConfigVista* pPolicyConfig;
 
-		const ERole reserved = eConsole;
-
 		hr = CoCreateInstance(__uuidof(CPolicyConfigVistaClient), nullptr, CLSCTX_ALL, __uuidof(IPolicyConfigVista), reinterpret_cast<LPVOID*>(&pPolicyConfig));
 
 		if (SUCCEEDED(hr))
 		{
-				hr = pPolicyConfig->SetDefaultEndpoint(devID, reserved);
+				hr = pPolicyConfig->SetDefaultEndpoint(devID, role);
 				pPolicyConfig->Release();
 		}
 

--- a/SetPlaybackDevice/SetPlaybackDevice/Main.cpp
+++ b/SetPlaybackDevice/SetPlaybackDevice/Main.cpp
@@ -37,6 +37,7 @@ int main(const int argc, const char * argv[])
   }
 	 else if (wcslen(arg) > 0)
 	 {
-	   SetAudioPlaybackDevice(arg);
+	   SetAudioPlaybackDevice(arg, eConsole);
+	   SetAudioPlaybackDevice(arg, eCommunications);
   }
 }


### PR DESCRIPTION
Useful for cases where apps like Discord use the default communication device.
Original solution suggested by MehdiMamas here: https://github.com/creepyLANguy/SoundSwitcher/pull/90/